### PR TITLE
Add root compose orchestration

### DIFF
--- a/ApiGatewayEcoF/.gitignore
+++ b/ApiGatewayEcoF/.gitignore
@@ -1,0 +1,34 @@
+# Temporary files
+.vs/
+*.user
+*.suo
+
+# Compiled binaries
+bin/
+obj/
+out/
+
+# Publish
+*.Publish.xml
+
+# Logs
+*.log
+*.tlog
+*.cache
+*.db
+*.pid
+*.tmp
+
+# Environment
+*.env
+.env.*
+
+# IDE settings
+.idea/
+.vscode/
+
+# OS files
+Thumbs.db
+.DS_Store
+
+docker-compose.override.yml

--- a/ApiGatewayEcoF/ApiGateway.sln
+++ b/ApiGatewayEcoF/ApiGateway.sln
@@ -1,0 +1,19 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiGateway.API", "src\ApiGateway.API\ApiGateway.API.csproj", "{4AB44BE2-24DB-4BAB-A778-EBD2DCCD5173}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {4AB44BE2-24DB-4BAB-A778-EBD2DCCD5173}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {4AB44BE2-24DB-4BAB-A778-EBD2DCCD5173}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {4AB44BE2-24DB-4BAB-A778-EBD2DCCD5173}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {4AB44BE2-24DB-4BAB-A778-EBD2DCCD5173}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/ApiGatewayEcoF/Dockerfile
+++ b/ApiGatewayEcoF/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY ["src/ApiGateway.API/ApiGateway.API.csproj", "src/ApiGateway.API/"]
+RUN dotnet restore "src/ApiGateway.API/ApiGateway.API.csproj"
+COPY . .
+WORKDIR "/src/src/ApiGateway.API"
+RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "ApiGateway.API.dll"]

--- a/ApiGatewayEcoF/docker-compose.yml
+++ b/ApiGatewayEcoF/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  api-gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: api_gateway
+    environment:
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
+      ASPNETCORE_URLS: "http://+:8080"
+    ports:
+      - "8085:8080"
+    networks:
+      - auth-network
+      - vehicle-network
+    depends_on:
+      - auth-service
+      - vehicle-service
+
+networks:
+  auth-network:
+    external: true
+  vehicle-network:
+    external: true

--- a/ApiGatewayEcoF/src/ApiGateway.API/ApiGateway.API.csproj
+++ b/ApiGatewayEcoF/src/ApiGateway.API/ApiGateway.API.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/ApiGatewayEcoF/src/ApiGateway.API/Program.cs
+++ b/ApiGatewayEcoF/src/ApiGateway.API/Program.cs
@@ -1,0 +1,12 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddReverseProxy()
+    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+
+var app = builder.Build();
+
+app.MapGet("/", () => "API Gateway running");
+
+app.MapReverseProxy();
+
+app.Run();

--- a/ApiGatewayEcoF/src/ApiGateway.API/appsettings.json
+++ b/ApiGatewayEcoF/src/ApiGateway.API/appsettings.json
@@ -1,0 +1,28 @@
+{
+  "ReverseProxy": {
+    "Routes": [
+      {
+        "RouteId": "auth",
+        "ClusterId": "authcluster",
+        "Match": { "Path": "/auth/{**catch-all}" }
+      },
+      {
+        "RouteId": "vehicle",
+        "ClusterId": "vehiclecluster",
+        "Match": { "Path": "/vehicle/{**catch-all}" }
+      }
+    ],
+    "Clusters": {
+      "authcluster": {
+        "Destinations": {
+          "auth_service": { "Address": "http://auth_service:8080/" }
+        }
+      },
+      "vehiclecluster": {
+        "Destinations": {
+          "vehicle_service": { "Address": "http://vehicle_service:8082/" }
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # GestionCombustible
+
+Este repositorio contiene los microservicios de autenticación y gestión de vehículos para el proyecto *GestionCombustible*. Ahora se añade un API Gateway sencillo basado en **YARP** que permite exponer los servicios de forma unificada para un front-end.
+
+## Microservicios existentes
+- **AuthServiceEcoF**: Servicio de autenticación (puerto 8081/8080).
+- **VehicleServiceEcoF**: Servicio de gestión de vehículos (puerto 8082).
+
+## Nuevo API Gateway
+El directorio `ApiGatewayEcoF` contiene un microservicio adicional construido con .NET 9 y el paquete `Yarp.ReverseProxy`. El gateway expone:
+
+- `/auth/*` → redirige a `AuthServiceEcoF`.
+- `/vehicle/*` → redirige a `VehicleServiceEcoF`.
+
+El gateway escucha en el puerto **8085** (configurable en `docker-compose.yml`).
+
+Para construir la imagen Docker:
+
+```bash
+docker compose -f ApiGatewayEcoF/docker-compose.yml build
+```
+
+## Levantar todos los servicios
+
+Desde la raíz del repositorio se puede iniciar la base de datos de autenticación,
+el microservicio de vehículos y el API Gateway con un único comando:
+
+```bash
+docker compose up --build
+```
+
+Esto utiliza el archivo `docker-compose.yml` situado en la raíz.
+
+## Estructura
+- `AuthServiceEcoF/` – microservicio de autenticación.
+- `VehicleServiceEcoF/` – microservicio de vehículos.
+- `ApiGatewayEcoF/` – API Gateway REST que unifica los anteriores.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,104 @@
+services:
+  auth-db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: auth_db
+    environment:
+      SA_PASSWORD: ${SA_PASSWORD}
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: "Express"
+    ports:
+      - "1434:1433"
+    networks:
+      - auth-network
+    volumes:
+      - auth_db_data:/var/opt/mssql
+
+  auth-service:
+    build:
+      context: ./AuthServiceEcoF
+      dockerfile: Dockerfile
+    container_name: auth_service
+    environment:
+      ConnectionStrings__DefaultConnection: "Server=auth-db,1433;Database=${DB_NAME};User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=true;Connection Timeout=30;"
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
+      ASPNETCORE_URLS: ${ASPNETCORE_URLS}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXPIRATION_MINUTES: ${JWT_EXPIRATION_MINUTES}
+      JWT_ISSUER: ${JWT_ISSUER}
+      JWT_AUDIENCE: ${JWT_AUDIENCE}
+      BCRYPT_WORK_FACTOR: ${BCRYPT_WORK_FACTOR}
+    ports:
+      - "8081:8081"
+      - "8080:8080"
+    depends_on:
+      - auth-db
+    networks:
+      - auth-network
+    restart: unless-stopped
+    command: >
+      sh -c "sleep 45 && dotnet AuthService.API.dll"
+
+  vehicle-db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: vehicle_db
+    environment:
+      SA_PASSWORD: ${SA_PASSWORD}
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: "Express"
+    ports:
+      - "1435:1433"
+    networks:
+      - vehicle-network
+    volumes:
+      - vehicle_db_data:/var/opt/mssql
+    restart: unless-stopped
+
+  vehicle-service:
+    build:
+      context: ./VehicleServiceEcoF
+      dockerfile: Dockerfile
+    container_name: vehicle_service
+    environment:
+      ConnectionStrings__DefaultConnection: "Server=vehicle-db,1433;Database=${DB_NAME};User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=true;Connection Timeout=30;"
+      ConnectionStrings__AuthService: "http://auth_service:8080"
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
+      ASPNETCORE_URLS: "http://+:8082"
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_ISSUER: ${JWT_ISSUER}
+      JWT_AUDIENCE: ${JWT_AUDIENCE}
+      JWT_EXPIRATION_MINUTES: ${JWT_EXPIRATION_MINUTES}
+      VEHICLE_SERVICE_NAME: ${VEHICLE_SERVICE_NAME}
+    ports:
+      - "8082:8082"
+    depends_on:
+      - vehicle-db
+    networks:
+      - vehicle-network
+    restart: unless-stopped
+
+  api-gateway:
+    build:
+      context: ./ApiGatewayEcoF
+      dockerfile: Dockerfile
+    container_name: api_gateway
+    environment:
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
+      ASPNETCORE_URLS: "http://+:8080"
+    ports:
+      - "8085:8080"
+    networks:
+      - auth-network
+      - vehicle-network
+    depends_on:
+      - auth-service
+      - vehicle-service
+
+networks:
+  auth-network:
+    driver: bridge
+  vehicle-network:
+    driver: bridge
+
+volumes:
+  auth_db_data:
+  vehicle_db_data:


### PR DESCRIPTION
## Summary
- add root `docker-compose.yml` to run Auth, Vehicle and the new API Gateway
- document how to start all services from the repository root

## Testing
- `dotnet --info` *(fails: command not found)*
- `dotnet build ApiGatewayEcoF/ApiGateway.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b80be66b08333aa15ba1275b1a721