### PR TITLE
Add RESTful API gateway

### DIFF
--- a/ApiGatewayEcoF/.gitignore
+++ b/ApiGatewayEcoF/.gitignore
@@ -1,0 +1,34 @@
+# Temporary files
+.vs/
+*.user
+*.suo
+
+# Compiled binaries
+bin/
+obj/
+out/
+
+# Publish
+*.Publish.xml
+
+# Logs
+*.log
+*.tlog
+*.cache
+*.db
+*.pid
+*.tmp
+
+# Environment
+*.env
+.env.*
+
+# IDE settings
+.idea/
+.vscode/
+
+# OS files
+Thumbs.db
+.DS_Store
+
+docker-compose.override.yml

--- a/ApiGatewayEcoF/ApiGateway.sln
+++ b/ApiGatewayEcoF/ApiGateway.sln
@@ -1,0 +1,31 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiGateway.API", "src\ApiGateway.API\ApiGateway.API.csproj", "{4AB44BE2-24DB-4BAB-A778-EBD2DCCD5173}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiGateway.Application", "src\ApiGateway.Application\ApiGateway.Application.csproj", "{622D0CBA-266C-4319-AD2B-654840BDA92D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiGateway.Infrastructure", "src\ApiGateway.Infrastructure\ApiGateway.Infrastructure.csproj", "{16FF8604-9FB1-416C-9DCC-21D0C29BE072}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {4AB44BE2-24DB-4BAB-A778-EBD2DCCD5173}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {4AB44BE2-24DB-4BAB-A778-EBD2DCCD5173}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {4AB44BE2-24DB-4BAB-A778-EBD2DCCD5173}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {4AB44BE2-24DB-4BAB-A778-EBD2DCCD5173}.Release|Any CPU.Build.0 = Release|Any CPU
+        {622D0CBA-266C-4319-AD2B-654840BDA92D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {622D0CBA-266C-4319-AD2B-654840BDA92D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {622D0CBA-266C-4319-AD2B-654840BDA92D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {622D0CBA-266C-4319-AD2B-654840BDA92D}.Release|Any CPU.Build.0 = Release|Any CPU
+        {16FF8604-9FB1-416C-9DCC-21D0C29BE072}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {16FF8604-9FB1-416C-9DCC-21D0C29BE072}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {16FF8604-9FB1-416C-9DCC-21D0C29BE072}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {16FF8604-9FB1-416C-9DCC-21D0C29BE072}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/ApiGatewayEcoF/Dockerfile
+++ b/ApiGatewayEcoF/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY ["src/ApiGateway.API/ApiGateway.API.csproj", "src/ApiGateway.API/"]
+COPY ["src/ApiGateway.Application/ApiGateway.Application.csproj", "src/ApiGateway.Application/"]
+COPY ["src/ApiGateway.Infrastructure/ApiGateway.Infrastructure.csproj", "src/ApiGateway.Infrastructure/"]
+RUN dotnet restore "src/ApiGateway.API/ApiGateway.API.csproj"
+COPY . .
+WORKDIR "/src/src/ApiGateway.API"
+RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "ApiGateway.API.dll"]

--- a/ApiGatewayEcoF/docker-compose.yml
+++ b/ApiGatewayEcoF/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  api-gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: api_gateway
+    environment:
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
+      ASPNETCORE_URLS: "http://+:8080"
+    ports:
+      - "8085:8080"
+    networks:
+      - auth-network
+      - vehicle-network
+    depends_on:
+      - auth-service
+      - vehicle-service
+
+networks:
+  auth-network:
+    external: true
+  vehicle-network:
+    external: true

--- a/ApiGatewayEcoF/src/ApiGateway.API/ApiGateway.API.csproj
+++ b/ApiGatewayEcoF/src/ApiGateway.API/ApiGateway.API.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ApiGateway.Application/ApiGateway.Application.csproj" />
+    <ProjectReference Include="../ApiGateway.Infrastructure/ApiGateway.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/ApiGatewayEcoF/src/ApiGateway.API/Controllers/AuthController.cs
+++ b/ApiGatewayEcoF/src/ApiGateway.API/Controllers/AuthController.cs
@@ -1,0 +1,59 @@
+using ApiGateway.Application.Interfaces;
+using AuthService.Protos;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ApiGateway.API.Controllers;
+
+[ApiController]
+[Route("auth")]
+public class AuthController : ControllerBase
+{
+    private readonly IAuthGateway _gateway;
+
+    public AuthController(IAuthGateway gateway)
+    {
+        _gateway = gateway;
+    }
+
+    [HttpPost("login")]
+    public async Task<ActionResult<LoginResponse>> Login(LoginRequest request)
+    {
+        var response = await _gateway.LoginAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("register")]
+    public async Task<ActionResult<RegisterResponse>> Register(RegisterRequest request)
+    {
+        var response = await _gateway.RegisterAsync(request);
+        return Ok(response);
+    }
+
+    [HttpGet("usuarios")]
+    public async Task<ActionResult<ListarUsuariosResponse>> ListarUsuarios()
+    {
+        var response = await _gateway.ListarUsuariosAsync();
+        return Ok(response);
+    }
+
+    [HttpGet("usuarios/rol/{rolId:int}")]
+    public async Task<ActionResult<ListarUsuariosPorRolResponse>> ListarUsuariosPorRol(int rolId)
+    {
+        var response = await _gateway.ListarUsuariosPorRolAsync(new ListarUsuariosPorRolRequest { RolId = rolId });
+        return Ok(response);
+    }
+
+    [HttpPost("usuarios/estado")]
+    public async Task<ActionResult<ActualizarEstadoUsuarioResponse>> ActualizarEstado(ActualizarEstadoUsuarioRequest request)
+    {
+        var response = await _gateway.ActualizarEstadoUsuarioAsync(request);
+        return Ok(response);
+    }
+
+    [HttpDelete("usuarios/{id:int}")]
+    public async Task<ActionResult<EliminarUsuarioResponse>> EliminarUsuario(int id)
+    {
+        var response = await _gateway.EliminarUsuarioAsync(new EliminarUsuarioRequest { UsuarioId = id });
+        return Ok(response);
+    }
+}

--- a/ApiGatewayEcoF/src/ApiGateway.API/Controllers/VehicleController.cs
+++ b/ApiGatewayEcoF/src/ApiGateway.API/Controllers/VehicleController.cs
@@ -1,0 +1,193 @@
+using ApiGateway.Application.Interfaces;
+using VehicleService.Protos;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ApiGateway.API.Controllers;
+
+[ApiController]
+[Route("vehicle")]
+public class VehicleController : ControllerBase
+{
+    private readonly IVehicleGateway _gateway;
+
+    public VehicleController(IVehicleGateway gateway)
+    {
+        _gateway = gateway;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<VehiculoResponse>> CrearVehiculo(CrearVehiculoRequest request)
+    {
+        var response = await _gateway.CrearVehiculoAsync(request);
+        return Ok(response);
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<VehiculoResponse>> ObtenerVehiculoPorId(int id)
+    {
+        var response = await _gateway.ObtenerVehiculoPorIdAsync(new ObtenerVehiculoPorIdRequest { VehiculoId = id });
+        return Ok(response);
+    }
+
+    [HttpGet("detalle/{id:int}")]
+    public async Task<ActionResult<VehiculoDetalleResponse>> ObtenerVehiculoDetalle(int id)
+    {
+        var response = await _gateway.ObtenerVehiculoDetalleAsync(new ObtenerVehiculoPorIdRequest { VehiculoId = id });
+        return Ok(response);
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<VehiculosResponse>> ObtenerTodosVehiculos()
+    {
+        var response = await _gateway.ObtenerTodosVehiculosAsync();
+        return Ok(response);
+    }
+
+    [HttpPut]
+    public async Task<ActionResult<OperationResponse>> ActualizarVehiculo(ActualizarVehiculoRequest request)
+    {
+        var response = await _gateway.ActualizarVehiculoAsync(request);
+        return Ok(response);
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<ActionResult<OperationResponse>> EliminarVehiculo(int id)
+    {
+        var response = await _gateway.EliminarVehiculoAsync(new EliminarVehiculoRequest { VehiculoId = id });
+        return Ok(response);
+    }
+
+    [HttpGet("codigo/{codigo}")]
+    public async Task<ActionResult<VehiculoResponse>> ObtenerPorCodigo(string codigo)
+    {
+        var response = await _gateway.ObtenerVehiculoPorCodigoAsync(new ObtenerVehiculoPorCodigoRequest { Codigo = codigo });
+        return Ok(response);
+    }
+
+    [HttpGet("placa/{placa}")]
+    public async Task<ActionResult<VehiculoResponse>> ObtenerPorPlaca(string placa)
+    {
+        var response = await _gateway.ObtenerVehiculoPorPlacaAsync(new ObtenerVehiculoPorPlacaRequest { Placa = placa });
+        return Ok(response);
+    }
+
+    [HttpPost("tipo-maquinaria")]
+    public async Task<ActionResult<VehiculosResponse>> ObtenerPorTipoMaquinaria(ObtenerVehiculosPorTipoMaquinariaRequest request)
+    {
+        var response = await _gateway.ObtenerVehiculosPorTipoMaquinariaAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("estado")]
+    public async Task<ActionResult<VehiculosResponse>> ObtenerPorEstado(ObtenerVehiculosPorEstadoRequest request)
+    {
+        var response = await _gateway.ObtenerVehiculosPorEstadoAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("filtrar")]
+    public async Task<ActionResult<VehiculosPagedResponse>> ObtenerFiltrados(FiltroVehiculosRequest request)
+    {
+        var response = await _gateway.ObtenerVehiculosFiltradosAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("cambiar-estado")]
+    public async Task<ActionResult<OperationResponse>> CambiarEstado(CambiarEstadoVehiculoRequest request)
+    {
+        var response = await _gateway.CambiarEstadoVehiculoAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("activar")]
+    public async Task<ActionResult<OperationResponse>> Activar(ActivarVehiculoRequest request)
+    {
+        var response = await _gateway.ActivarVehiculoAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("mantenimiento")]
+    public async Task<ActionResult<OperationResponse>> EnviarAMantenimiento(EnviarAMantenimientoRequest request)
+    {
+        var response = await _gateway.EnviarAMantenimientoAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("reparacion")]
+    public async Task<ActionResult<OperationResponse>> EnviarAReparacion(EnviarAReparacionRequest request)
+    {
+        var response = await _gateway.EnviarAReparacionAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("inactivar")]
+    public async Task<ActionResult<OperationResponse>> Inactivar(InactivarVehiculoRequest request)
+    {
+        var response = await _gateway.InactivarVehiculoAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("reservar")]
+    public async Task<ActionResult<OperationResponse>> Reservar(ReservarVehiculoRequest request)
+    {
+        var response = await _gateway.ReservarVehiculoAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("liberar")]
+    public async Task<ActionResult<OperationResponse>> LiberarReserva(LiberarReservaRequest request)
+    {
+        var response = await _gateway.LiberarReservaAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("odometro")]
+    public async Task<ActionResult<OperationResponse>> ActualizarOdometro(ActualizarOdometroRequest request)
+    {
+        var response = await _gateway.ActualizarOdometroAsync(request);
+        return Ok(response);
+    }
+
+    [HttpPost("registrar-mantenimiento")]
+    public async Task<ActionResult<OperationResponse>> RegistrarMantenimiento(RegistrarMantenimientoRequest request)
+    {
+        var response = await _gateway.RegistrarMantenimientoAsync(request);
+        return Ok(response);
+    }
+
+    [HttpGet("activos")]
+    public async Task<ActionResult<VehiculosResponse>> ObtenerActivos()
+    {
+        var response = await _gateway.ObtenerVehiculosActivosAsync();
+        return Ok(response);
+    }
+
+    [HttpGet("disponibles")]
+    public async Task<ActionResult<VehiculosResponse>> ObtenerDisponibles()
+    {
+        var response = await _gateway.ObtenerVehiculosDisponiblesAsync();
+        return Ok(response);
+    }
+
+    [HttpGet("mantenimiento-vencido")]
+    public async Task<ActionResult<VehiculosResponse>> ObtenerMantenimientoVencido()
+    {
+        var response = await _gateway.ObtenerVehiculosConMantenimientoVencidoAsync();
+        return Ok(response);
+    }
+
+    [HttpGet("existe-codigo/{codigo}")]
+    public async Task<ActionResult<ExisteVehiculoResponse>> ExisteConCodigo(string codigo)
+    {
+        var response = await _gateway.ExisteVehiculoConCodigoAsync(new ExisteVehiculoConCodigoRequest { Codigo = codigo });
+        return Ok(response);
+    }
+
+    [HttpGet("existe-placa/{placa}")]
+    public async Task<ActionResult<ExisteVehiculoResponse>> ExisteConPlaca(string placa)
+    {
+        var response = await _gateway.ExisteVehiculoConPlacaAsync(new ExisteVehiculoConPlacaRequest { Placa = placa });
+        return Ok(response);
+    }
+}
+

--- a/ApiGatewayEcoF/src/ApiGateway.API/Program.cs
+++ b/ApiGatewayEcoF/src/ApiGateway.API/Program.cs
@@ -1,0 +1,20 @@
+using ApiGateway.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+
+builder.Services.AddReverseProxy()
+    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+
+builder.Services.AddInfrastructure(builder.Configuration);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+app.MapReverseProxy();
+app.MapGet("/", () => "API Gateway running");
+
+app.Run();

--- a/ApiGatewayEcoF/src/ApiGateway.API/appsettings.json
+++ b/ApiGatewayEcoF/src/ApiGateway.API/appsettings.json
@@ -1,0 +1,33 @@
+{
+  "ReverseProxy": {
+    "Routes": [
+      {
+        "RouteId": "auth",
+        "ClusterId": "authcluster",
+        "Match": { "Path": "/auth/{**catch-all}" }
+      },
+      {
+        "RouteId": "vehicle",
+        "ClusterId": "vehiclecluster",
+        "Match": { "Path": "/vehicle/{**catch-all}" }
+      }
+    ],
+    "Clusters": {
+      "authcluster": {
+        "Destinations": {
+          "auth_service": { "Address": "http://auth_service:8080/" }
+        }
+      },
+      "vehiclecluster": {
+        "Destinations": {
+          "vehicle_service": { "Address": "http://vehicle_service:8082/" }
+        }
+      }
+    }
+  }
+  ,
+  "Services": {
+    "Auth": "http://auth_service:8080",
+    "Vehicle": "http://vehicle_service:8082"
+  }
+}

--- a/ApiGatewayEcoF/src/ApiGateway.Application/ApiGateway.Application.csproj
+++ b/ApiGatewayEcoF/src/ApiGateway.Application/ApiGateway.Application.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/ApiGatewayEcoF/src/ApiGateway.Application/Interfaces/IAuthGateway.cs
+++ b/ApiGatewayEcoF/src/ApiGateway.Application/Interfaces/IAuthGateway.cs
@@ -1,0 +1,14 @@
+namespace ApiGateway.Application.Interfaces;
+
+using AuthService.Protos;
+using Google.Protobuf.WellKnownTypes;
+
+public interface IAuthGateway
+{
+    Task<LoginResponse> LoginAsync(LoginRequest request);
+    Task<RegisterResponse> RegisterAsync(RegisterRequest request);
+    Task<ListarUsuariosResponse> ListarUsuariosAsync();
+    Task<ListarUsuariosPorRolResponse> ListarUsuariosPorRolAsync(ListarUsuariosPorRolRequest request);
+    Task<ActualizarEstadoUsuarioResponse> ActualizarEstadoUsuarioAsync(ActualizarEstadoUsuarioRequest request);
+    Task<EliminarUsuarioResponse> EliminarUsuarioAsync(EliminarUsuarioRequest request);
+}

--- a/ApiGatewayEcoF/src/ApiGateway.Application/Interfaces/IVehicleGateway.cs
+++ b/ApiGatewayEcoF/src/ApiGateway.Application/Interfaces/IVehicleGateway.cs
@@ -1,0 +1,38 @@
+namespace ApiGateway.Application.Interfaces;
+
+using VehicleService.Protos;
+using Google.Protobuf.WellKnownTypes;
+
+public interface IVehicleGateway
+{
+    Task<VehiculoResponse> CrearVehiculoAsync(CrearVehiculoRequest request);
+    Task<VehiculoResponse> ObtenerVehiculoPorIdAsync(ObtenerVehiculoPorIdRequest request);
+    Task<VehiculoDetalleResponse> ObtenerVehiculoDetalleAsync(ObtenerVehiculoPorIdRequest request);
+    Task<VehiculosResponse> ObtenerTodosVehiculosAsync();
+    Task<OperationResponse> ActualizarVehiculoAsync(ActualizarVehiculoRequest request);
+    Task<OperationResponse> EliminarVehiculoAsync(EliminarVehiculoRequest request);
+
+    Task<VehiculoResponse> ObtenerVehiculoPorCodigoAsync(ObtenerVehiculoPorCodigoRequest request);
+    Task<VehiculoResponse> ObtenerVehiculoPorPlacaAsync(ObtenerVehiculoPorPlacaRequest request);
+    Task<VehiculosResponse> ObtenerVehiculosPorTipoMaquinariaAsync(ObtenerVehiculosPorTipoMaquinariaRequest request);
+    Task<VehiculosResponse> ObtenerVehiculosPorEstadoAsync(ObtenerVehiculosPorEstadoRequest request);
+    Task<VehiculosPagedResponse> ObtenerVehiculosFiltradosAsync(FiltroVehiculosRequest request);
+
+    Task<OperationResponse> CambiarEstadoVehiculoAsync(CambiarEstadoVehiculoRequest request);
+    Task<OperationResponse> ActivarVehiculoAsync(ActivarVehiculoRequest request);
+    Task<OperationResponse> EnviarAMantenimientoAsync(EnviarAMantenimientoRequest request);
+    Task<OperationResponse> EnviarAReparacionAsync(EnviarAReparacionRequest request);
+    Task<OperationResponse> InactivarVehiculoAsync(InactivarVehiculoRequest request);
+    Task<OperationResponse> ReservarVehiculoAsync(ReservarVehiculoRequest request);
+    Task<OperationResponse> LiberarReservaAsync(LiberarReservaRequest request);
+
+    Task<OperationResponse> ActualizarOdometroAsync(ActualizarOdometroRequest request);
+    Task<OperationResponse> RegistrarMantenimientoAsync(RegistrarMantenimientoRequest request);
+
+    Task<VehiculosResponse> ObtenerVehiculosActivosAsync();
+    Task<VehiculosResponse> ObtenerVehiculosDisponiblesAsync();
+    Task<VehiculosResponse> ObtenerVehiculosConMantenimientoVencidoAsync();
+
+    Task<ExisteVehiculoResponse> ExisteVehiculoConCodigoAsync(ExisteVehiculoConCodigoRequest request);
+    Task<ExisteVehiculoResponse> ExisteVehiculoConPlacaAsync(ExisteVehiculoConPlacaRequest request);
+}

--- a/ApiGatewayEcoF/src/ApiGateway.Infrastructure/ApiGateway.Infrastructure.csproj
+++ b/ApiGatewayEcoF/src/ApiGateway.Infrastructure/ApiGateway.Infrastructure.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Grpc.Net.Client" Version="2.65.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.25.3" />
+    <PackageReference Include="Grpc.Tools" Version="2.65.0" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ApiGateway.Application/ApiGateway.Application.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="../../../AuthServiceEcoF/src/AuthService.API/Protos/auth.proto" GrpcServices="Client" />
+    <Protobuf Include="../../../VehicleServiceEcoF/src/VehicleService.API/Protos/vehicle_service.proto" GrpcServices="Client" />
+  </ItemGroup>
+</Project>

--- a/ApiGatewayEcoF/src/ApiGateway.Infrastructure/DependencyInjection.cs
+++ b/ApiGatewayEcoF/src/ApiGateway.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,21 @@
+using ApiGateway.Application.Interfaces;
+using ApiGateway.Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ApiGateway.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddGrpcClient<AuthService.Protos.AuthService.AuthServiceClient>(o =>
+            o.Address = new Uri(configuration["Services:Auth"]!));
+        services.AddGrpcClient<VehicleService.Protos.VehicleService.VehicleServiceClient>(o =>
+            o.Address = new Uri(configuration["Services:Vehicle"]!));
+
+        services.AddScoped<IAuthGateway, AuthGatewayGrpc>();
+        services.AddScoped<IVehicleGateway, VehicleGatewayGrpc>();
+        return services;
+    }
+}

--- a/ApiGatewayEcoF/src/ApiGateway.Infrastructure/Services/AuthGatewayGrpc.cs
+++ b/ApiGatewayEcoF/src/ApiGateway.Infrastructure/Services/AuthGatewayGrpc.cs
@@ -1,0 +1,27 @@
+using ApiGateway.Application.Interfaces;
+using AuthService.Protos;
+using Google.Protobuf.WellKnownTypes;
+
+namespace ApiGateway.Infrastructure.Services;
+
+public class AuthGatewayGrpc : IAuthGateway
+{
+    private readonly AuthService.AuthServiceClient _client;
+
+    public AuthGatewayGrpc(AuthService.AuthServiceClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<LoginResponse> LoginAsync(LoginRequest request) => await _client.LoginAsync(request);
+
+    public async Task<RegisterResponse> RegisterAsync(RegisterRequest request) => await _client.RegisterAsync(request);
+
+    public async Task<ListarUsuariosResponse> ListarUsuariosAsync() => await _client.ListarUsuariosAsync(new Empty());
+
+    public async Task<ListarUsuariosPorRolResponse> ListarUsuariosPorRolAsync(ListarUsuariosPorRolRequest request) => await _client.ListarUsuariosPorRolAsync(request);
+
+    public async Task<ActualizarEstadoUsuarioResponse> ActualizarEstadoUsuarioAsync(ActualizarEstadoUsuarioRequest request) => await _client.ActualizarEstadoUsuarioAsync(request);
+
+    public async Task<EliminarUsuarioResponse> EliminarUsuarioAsync(EliminarUsuarioRequest request) => await _client.EliminarUsuarioAsync(request);
+}

--- a/ApiGatewayEcoF/src/ApiGateway.Infrastructure/Services/VehicleGatewayGrpc.cs
+++ b/ApiGatewayEcoF/src/ApiGateway.Infrastructure/Services/VehicleGatewayGrpc.cs
@@ -1,0 +1,66 @@
+using ApiGateway.Application.Interfaces;
+using VehicleService.Protos;
+using Google.Protobuf.WellKnownTypes;
+
+namespace ApiGateway.Infrastructure.Services;
+
+public class VehicleGatewayGrpc : IVehicleGateway
+{
+    private readonly VehicleService.VehicleServiceClient _client;
+
+    public VehicleGatewayGrpc(VehicleService.VehicleServiceClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<VehiculoResponse> CrearVehiculoAsync(CrearVehiculoRequest request) => await _client.CrearVehiculoAsync(request);
+
+    public async Task<VehiculoResponse> ObtenerVehiculoPorIdAsync(ObtenerVehiculoPorIdRequest request) => await _client.ObtenerVehiculoPorIdAsync(request);
+
+    public async Task<VehiculoDetalleResponse> ObtenerVehiculoDetalleAsync(ObtenerVehiculoPorIdRequest request) => await _client.ObtenerVehiculoDetalleAsync(request);
+
+    public async Task<VehiculosResponse> ObtenerTodosVehiculosAsync() => await _client.ObtenerTodosVehiculosAsync(new Empty());
+
+    public async Task<OperationResponse> ActualizarVehiculoAsync(ActualizarVehiculoRequest request) => await _client.ActualizarVehiculoAsync(request);
+
+    public async Task<OperationResponse> EliminarVehiculoAsync(EliminarVehiculoRequest request) => await _client.EliminarVehiculoAsync(request);
+
+    public async Task<VehiculoResponse> ObtenerVehiculoPorCodigoAsync(ObtenerVehiculoPorCodigoRequest request) => await _client.ObtenerVehiculoPorCodigoAsync(request);
+
+    public async Task<VehiculoResponse> ObtenerVehiculoPorPlacaAsync(ObtenerVehiculoPorPlacaRequest request) => await _client.ObtenerVehiculoPorPlacaAsync(request);
+
+    public async Task<VehiculosResponse> ObtenerVehiculosPorTipoMaquinariaAsync(ObtenerVehiculosPorTipoMaquinariaRequest request) => await _client.ObtenerVehiculosPorTipoMaquinariaAsync(request);
+
+    public async Task<VehiculosResponse> ObtenerVehiculosPorEstadoAsync(ObtenerVehiculosPorEstadoRequest request) => await _client.ObtenerVehiculosPorEstadoAsync(request);
+
+    public async Task<VehiculosPagedResponse> ObtenerVehiculosFiltradosAsync(FiltroVehiculosRequest request) => await _client.ObtenerVehiculosFiltradosAsync(request);
+
+    public async Task<OperationResponse> CambiarEstadoVehiculoAsync(CambiarEstadoVehiculoRequest request) => await _client.CambiarEstadoVehiculoAsync(request);
+
+    public async Task<OperationResponse> ActivarVehiculoAsync(ActivarVehiculoRequest request) => await _client.ActivarVehiculoAsync(request);
+
+    public async Task<OperationResponse> EnviarAMantenimientoAsync(EnviarAMantenimientoRequest request) => await _client.EnviarAMantenimientoAsync(request);
+
+    public async Task<OperationResponse> EnviarAReparacionAsync(EnviarAReparacionRequest request) => await _client.EnviarAReparacionAsync(request);
+
+    public async Task<OperationResponse> InactivarVehiculoAsync(InactivarVehiculoRequest request) => await _client.InactivarVehiculoAsync(request);
+
+    public async Task<OperationResponse> ReservarVehiculoAsync(ReservarVehiculoRequest request) => await _client.ReservarVehiculoAsync(request);
+
+    public async Task<OperationResponse> LiberarReservaAsync(LiberarReservaRequest request) => await _client.LiberarReservaAsync(request);
+
+    public async Task<OperationResponse> ActualizarOdometroAsync(ActualizarOdometroRequest request) => await _client.ActualizarOdometroAsync(request);
+
+    public async Task<OperationResponse> RegistrarMantenimientoAsync(RegistrarMantenimientoRequest request) => await _client.RegistrarMantenimientoAsync(request);
+
+    public async Task<VehiculosResponse> ObtenerVehiculosActivosAsync() => await _client.ObtenerVehiculosActivosAsync(new Empty());
+
+    public async Task<VehiculosResponse> ObtenerVehiculosDisponiblesAsync() => await _client.ObtenerVehiculosDisponiblesAsync(new Empty());
+
+    public async Task<VehiculosResponse> ObtenerVehiculosConMantenimientoVencidoAsync() => await _client.ObtenerVehiculosConMantenimientoVencidoAsync(new Empty());
+
+    public async Task<ExisteVehiculoResponse> ExisteVehiculoConCodigoAsync(ExisteVehiculoConCodigoRequest request) => await _client.ExisteVehiculoConCodigoAsync(request);
+
+    public async Task<ExisteVehiculoResponse> ExisteVehiculoConPlacaAsync(ExisteVehiculoConPlacaRequest request) => await _client.ExisteVehiculoConPlacaAsync(request);
+}
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # GestionCombustible
+
+Este repositorio contiene los microservicios de autenticación y gestión de vehículos para el proyecto *GestionCombustible*. Ahora se añade un API Gateway REST que se apoya en **YARP** para exponer los servicios de forma unificada para un front-end.
+
+## Microservicios existentes
+- **AuthServiceEcoF**: Servicio de autenticación (puerto 8081/8080).
+- **VehicleServiceEcoF**: Servicio de gestión de vehículos (puerto 8082).
+
+## Nuevo API Gateway
+El directorio `ApiGatewayEcoF` contiene un microservicio adicional construido con .NET 9. Se aplica una separación en capas (API, Application e Infrastructure) para mantener la arquitectura limpia. El gateway genera clientes gRPC a partir de los **protos** y publica un endpoint REST por cada operación expuesta por los microservicios. Algunos ejemplos:
+
+- `POST /auth/login` para el inicio de sesión.
+- `GET /auth/usuarios` listado de usuarios.
+- `POST /vehicle/cambiar-estado` cambio de estado de un vehículo.
+- `GET /vehicle/activos` listado de vehículos activos.
+
+El gateway escucha en el puerto **8085** (configurable en `docker-compose.yml`).
+
+Para construir la imagen Docker:
+
+```bash
+docker compose -f ApiGatewayEcoF/docker-compose.yml build
+```
+
+## Levantar todos los servicios
+
+Desde la raíz del repositorio se puede iniciar la base de datos de autenticación,
+el microservicio de vehículos y el API Gateway con un único comando:
+
+```bash
+docker compose up --build
+```
+
+Esto utiliza el archivo `docker-compose.yml` situado en la raíz.
+
+## Estructura
+- `AuthServiceEcoF/` – microservicio de autenticación.
+- `VehicleServiceEcoF/` – microservicio de vehículos.
+- `ApiGatewayEcoF/` – API Gateway REST que unifica los anteriores.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,104 @@
+services:
+  auth-db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: auth_db
+    environment:
+      SA_PASSWORD: ${SA_PASSWORD}
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: "Express"
+    ports:
+      - "1434:1433"
+    networks:
+      - auth-network
+    volumes:
+      - auth_db_data:/var/opt/mssql
+
+  auth-service:
+    build:
+      context: ./AuthServiceEcoF
+      dockerfile: Dockerfile
+    container_name: auth_service
+    environment:
+      ConnectionStrings__DefaultConnection: "Server=auth-db,1433;Database=${DB_NAME};User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=true;Connection Timeout=30;"
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
+      ASPNETCORE_URLS: ${ASPNETCORE_URLS}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXPIRATION_MINUTES: ${JWT_EXPIRATION_MINUTES}
+      JWT_ISSUER: ${JWT_ISSUER}
+      JWT_AUDIENCE: ${JWT_AUDIENCE}
+      BCRYPT_WORK_FACTOR: ${BCRYPT_WORK_FACTOR}
+    ports:
+      - "8081:8081"
+      - "8080:8080"
+    depends_on:
+      - auth-db
+    networks:
+      - auth-network
+    restart: unless-stopped
+    command: >
+      sh -c "sleep 45 && dotnet AuthService.API.dll"
+
+  vehicle-db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: vehicle_db
+    environment:
+      SA_PASSWORD: ${SA_PASSWORD}
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: "Express"
+    ports:
+      - "1435:1433"
+    networks:
+      - vehicle-network
+    volumes:
+      - vehicle_db_data:/var/opt/mssql
+    restart: unless-stopped
+
+  vehicle-service:
+    build:
+      context: ./VehicleServiceEcoF
+      dockerfile: Dockerfile
+    container_name: vehicle_service
+    environment:
+      ConnectionStrings__DefaultConnection: "Server=vehicle-db,1433;Database=${DB_NAME};User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=true;Connection Timeout=30;"
+      ConnectionStrings__AuthService: "http://auth_service:8080"
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
+      ASPNETCORE_URLS: "http://+:8082"
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_ISSUER: ${JWT_ISSUER}
+      JWT_AUDIENCE: ${JWT_AUDIENCE}
+      JWT_EXPIRATION_MINUTES: ${JWT_EXPIRATION_MINUTES}
+      VEHICLE_SERVICE_NAME: ${VEHICLE_SERVICE_NAME}
+    ports:
+      - "8082:8082"
+    depends_on:
+      - vehicle-db
+    networks:
+      - vehicle-network
+    restart: unless-stopped
+
+  api-gateway:
+    build:
+      context: ./ApiGatewayEcoF
+      dockerfile: Dockerfile
+    container_name: api_gateway
+    environment:
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
+      ASPNETCORE_URLS: "http://+:8080"
+    ports:
+      - "8085:8080"
+    networks:
+      - auth-network
+      - vehicle-network
+    depends_on:
+      - auth-service
+      - vehicle-service
+
+networks:
+  auth-network:
+    driver: bridge
+  vehicle-network:
+    driver: bridge
+
+volumes:
+  auth_db_data:
+  vehicle_db_data:


### PR DESCRIPTION
## Summary
- implement Clean Architecture with Application and Infrastructure layers
- expose all proto operations via Auth and Vehicle controllers
- configure dependency injection and reverse proxy in gateway
- document the layered gateway and example routes in the README

## Testing
- `dotnet --info` *(fails: command not found)*
- `dotnet build ApiGatewayEcoF/ApiGateway.sln` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686b80be66b08333aa15ba1275b1a721