### PR TITLE
Add React frontend consuming API Gateway

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,21 @@
+# Frontend React
+
+Este directorio contiene una aplicación React construida con Vite que consume los endpoints del API Gateway.
+
+Se organiza de forma sencilla siguiendo principios de **arquitectura limpia**:
+
+- `src/api` contiene los servicios de acceso a datos.
+- `src/contexts` mantiene el estado de autenticación y roles.
+- `src/components` expone componentes reutilizables como `Navbar` y `PrivateRoute`.
+- `src/pages` incluye las páginas de la aplicación.
+
+La interfaz es dinámica según el rol obtenido desde el token JWT. Sólo el rol **Administrador** puede acceder a la gestión de usuarios.
+
+Para desarrollar:
+
+```bash
+npm install  # (solo la primera vez)
+npm run dev  # levanta Vite en el puerto 5173
+```
+
+La URL del API Gateway se toma de forma relativa (`/`), por lo que la aplicación puede servirse detrás del mismo dominio.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gestion Combustible</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "gestion-combustible-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.2",
+    "jwt-decode": "^3.1.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.4.2",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,43 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { AuthProvider } from './contexts/AuthContext';
+import { PrivateRoute } from './components/PrivateRoute';
+import { Navbar } from './components/Navbar';
+import { LoginPage } from './pages/LoginPage';
+import { Dashboard } from './pages/Dashboard';
+import { UserManagement } from './pages/UserManagement';
+import { Vehicles } from './pages/Vehicles';
+
+export const App = () => (
+  <AuthProvider>
+    <BrowserRouter>
+      <Navbar />
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          path="/users"
+          element={
+            <PrivateRoute roles={["Administrador"]}>
+              <UserManagement />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/vehicles"
+          element={
+            <PrivateRoute>
+              <Vehicles />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/"
+          element={
+            <PrivateRoute>
+              <Dashboard />
+            </PrivateRoute>
+          }
+        />
+      </Routes>
+    </BrowserRouter>
+  </AuthProvider>
+);

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,19 @@
+import { apiFetch } from './base';
+
+export interface LoginRequest {
+  correo: string;
+  contrasena: string;
+}
+
+export interface LoginResponse {
+  exito: boolean;
+  mensaje: string;
+  token: string;
+}
+
+export async function login(data: LoginRequest): Promise<LoginResponse> {
+  return apiFetch<LoginResponse>('auth/login', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}

--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -1,0 +1,18 @@
+export const API_URL = '/'; // relative to gateway
+
+export async function apiFetch<T>(
+  path: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const token = localStorage.getItem('token');
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+    ...(options.headers || {}),
+  };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const res = await fetch(API_URL + path, { ...options, headers });
+  if (!res.ok) {
+    throw new Error(`API error: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+export const Navbar = () => {
+  const { roles, logout } = useAuth();
+  const isAdmin = roles.includes('Administrador');
+
+  return (
+    <nav>
+      <Link to="/">Inicio</Link>
+      {' | '}
+      <Link to="/vehicles">Vehículos</Link>
+      {' | '}
+      {isAdmin && <Link to="/users">Usuarios</Link>}
+      {' | '}
+      <button onClick={logout}>Salir</button>
+    </nav>
+  );
+};

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,0 +1,16 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+export const PrivateRoute = ({ roles, children }: { roles?: string[]; children: JSX.Element }) => {
+  const { token, roles: userRoles } = useAuth();
+
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (roles && !roles.some(r => userRoles.includes(r))) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+};

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,63 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import jwtDecode from 'jwt-decode';
+
+interface JwtPayload {
+  email?: string;
+  role?: string | string[];
+  [key: string]: any;
+}
+
+interface AuthState {
+  token: string | null;
+  roles: string[];
+  login: (token: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(
+    () => localStorage.getItem('token')
+  );
+  const [roles, setRoles] = useState<string[]>(() => {
+    if (token) return extractRoles(token);
+    return [];
+  });
+
+  const login = (newToken: string) => {
+    localStorage.setItem('token', newToken);
+    setToken(newToken);
+    setRoles(extractRoles(newToken));
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+    setRoles([]);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, roles, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('AuthContext not found');
+  return ctx;
+};
+
+function extractRoles(token: string): string[] {
+  try {
+    const decoded = jwtDecode<JwtPayload>(token);
+    const r = decoded.role;
+    if (Array.isArray(r)) return r;
+    if (typeof r === 'string') return [r];
+    return [];
+  } catch {
+    return [];
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,3 @@
+export const Dashboard = () => {
+  return <h2>Bienvenido al sistema</h2>;
+};

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { login } from '../api/auth';
+import { useAuth } from '../contexts/AuthContext';
+
+export const LoginPage = () => {
+  const navigate = useNavigate();
+  const { login: saveToken } = useAuth();
+  const [correo, setCorreo] = useState('');
+  const [contrasena, setContrasena] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const res = await login({ correo, contrasena });
+      if (res.exito) {
+        saveToken(res.token);
+        navigate('/');
+      } else {
+        setError(res.mensaje);
+      }
+    } catch (err) {
+      setError('Error al iniciar sesión');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>Correo</label>
+        <input value={correo} onChange={e => setCorreo(e.target.value)} />
+      </div>
+      <div>
+        <label>Contraseña</label>
+        <input type="password" value={contrasena} onChange={e => setContrasena(e.target.value)} />
+      </div>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <button type="submit">Entrar</button>
+    </form>
+  );
+};

--- a/frontend/src/pages/UserManagement.tsx
+++ b/frontend/src/pages/UserManagement.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { apiFetch } from '../api/base';
+
+interface UsuarioDto {
+  usuarioId: number;
+  nombre: string;
+  apellido: string;
+  correo: string;
+  nombreUsuario: string;
+  estaActivo: boolean;
+  roles: string[];
+}
+
+export const UserManagement = () => {
+  const [usuarios, setUsuarios] = useState<UsuarioDto[]>([]);
+
+  useEffect(() => {
+    apiFetch<{ usuarios: UsuarioDto[] }>('auth/usuarios')
+      .then(r => setUsuarios(r.usuarios))
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <div>
+      <h2>Usuarios</h2>
+      <ul>
+        {usuarios.map(u => (
+          <li key={u.usuarioId}>{u.nombre} {u.apellido} - {u.roles.join(', ')}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/frontend/src/pages/Vehicles.tsx
+++ b/frontend/src/pages/Vehicles.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { apiFetch } from '../api/base';
+
+interface VehiculoDto {
+  vehiculoId: number;
+  codigo: string;
+  placa: string;
+  descripcion: string;
+}
+
+export const Vehicles = () => {
+  const [items, setItems] = useState<VehiculoDto[]>([]);
+
+  useEffect(() => {
+    apiFetch<{ vehiculos: VehiculoDto[] }>('vehicle')
+      .then(r => setItems(r.vehiculos))
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <div>
+      <h2>Vehículos</h2>
+      <ul>
+        {items.map(v => (
+          <li key={v.vehiculoId}>{v.codigo} - {v.placa}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add frontend directory with React application using Vite
- include AuthContext with JWT role extraction
- dynamic routes and menu based on roles (admin can manage users)
- document frontend usage and structure

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be3f478348333a67c370c21328488